### PR TITLE
Add setIO() function to easy embedding composer in other projects

### DIFF
--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -254,6 +254,14 @@ class Application extends BaseApplication
         return $this->io;
     }
 
+    /**
+     * @param  IOInterface       $io
+     */
+    public function setIO(IOInterface $io)
+    {
+        $this->io = $io; 
+    }
+
     public function getHelp()
     {
         return self::$logo . parent::getHelp();


### PR DESCRIPTION
Hello. I just want to embed Composer in our framework, but i dont see function setIO(). So i cant call $app->getComposer().

Please, add it.
